### PR TITLE
Updated error handling and optional BusinessKey in ReqMessage

### DIFF
--- a/message.go
+++ b/message.go
@@ -1,5 +1,7 @@
 package camunda_client_go
 
+import "log/slog"
+
 // Message a client for Message API
 type Message struct {
 	client *Client
@@ -8,7 +10,7 @@ type Message struct {
 // ReqMessage a request to send a message
 type ReqMessage struct {
 	MessageName       string               `json:"messageName"`
-	BusinessKey       string               `json:"businessKey"`
+	BusinessKey       string               `json:"businessKey,omitempty"`
 	ProcessInstanceId *string              `json:"processInstanceId,omitempty"`
 	ProcessVariables  *map[string]Variable `json:"processVariables,omitempty"`
 	CorrelationKeys   *map[string]Variable `json:"correlationKeys,omitempty"`
@@ -18,7 +20,9 @@ type ReqMessage struct {
 func (m *Message) SendMessage(query *ReqMessage) error {
 	res, err := m.client.doPostJson("/message", map[string]string{}, query)
 	if res != nil {
-		res.Body.Close()
+		if closeErr := res.Body.Close(); closeErr != nil {
+			slog.Default().Error("Failed to close response body", "error", closeErr)
+		}
 	}
 	return err
 }


### PR DESCRIPTION
Introduced logging for response body close errors and made 'BusinessKey' field in ReqMessage struct optional. Now 'BusinessKey' can be omitted if it has no value assigned to it, improving error handling and flexibility in struct usage.